### PR TITLE
Players must kill X% of AI before loot spawns

### DIFF
--- a/WAI/missions/missions/weapon_cache.sqf
+++ b/WAI/missions/missions/weapon_cache.sqf
@@ -1,6 +1,6 @@
 //Weapon Cache
 
-private ["_numSpawned","_numKillReq","_position","_box","_missiontimeout","_cleanmission","_playerPresent","_starttime","_currenttime","_cleanunits","_rndnum","_rndgro","_num_guns","_num_tools","_num_items"];
+private ["_dropPosition","_effectSmoke","_numSpawned","_numKillReq","_position","_box","_missiontimeout","_cleanmission","_playerPresent","_starttime","_currenttime","_cleanunits","_rndnum","_rndgro","_num_guns","_num_tools","_num_items"];
 
 _position 		= safepos call BIS_fnc_findSafePos;
 diag_log 		format["WAI: Mission Weapon cache started at %1",_position];


### PR DESCRIPTION
Players must kill 75% of AI before loot spawns
- Add  `wai_RequiredKillPercent = 0.75;` to missionCfg.sqf

if pull is accepted then this needs to be added to all others missions
