### PR TITLE
Improve weapon clean up from bodies.

### DIFF
--- a/WAI/compile/on_kill.sqf
+++ b/WAI/compile/on_kill.sqf
@@ -1,6 +1,6 @@
 if (isServer) then {
 
-	private ["_rockets","_launcher","_type","_skin","_gain","_mission","_ainum","_unit","_player","_humanity","_banditkills","_humankills","_humanitygain"];
+	private ["_weaponclip","_weaponclips","_weaponammolist","_rockets","_launcher","_type","_skin","_gain","_mission","_ainum","_unit","_player","_humanity","_banditkills","_humankills","_humanitygain"];
 	
 	_unit 		= _this select 0;
 	_player 	= _this select 1;
@@ -61,9 +61,20 @@ if (isServer) then {
 			};
 		};
 
-		if (ai_clear_body) then {
-			{_unit removeMagazine _x;} count (magazines _unit);
-			{_unit removeWeapon _x;} count (weapons _unit);
+		_weaponammolist 	= ai_wep_assault + ai_wep_sniper + ai_wep_machine;
+		for "_x" from 0 to ((count _weaponammolist) -1) do
+		{
+			_weaponclip 	= [(_weaponammolist select _x) select 1];
+			_weaponclips 	= _weaponclips + _weaponclip;
+		};
+
+		if (ai_clear_weapon) then {
+			_unit removeWeapon (primaryWeapon _unit);
+			{
+				if (_x in _weaponclips) then {
+					_unit removeMagazine _x;
+				};
+			} count (magazines _unit);
 		};
 
 		if (ai_share_info) then {
@@ -80,17 +91,16 @@ if (isServer) then {
 
 			removeBackpack _unit;
 			removeAllWeapons _unit;
-
-			{
-				_unit removeMagazine _x
-			} count magazines _unit;
+			{_unit removeMagazine _x;} count magazines _unit;
 
 		} else {
 
 			if ((random 100) <= ai_roadkill_damageweapon) then {
 
+				removeBackpack _unit;
 				removeAllWeapons _unit;
-				
+				{_unit removeMagazine _x;} count magazines _unit;
+
 			};
 
 		};

--- a/WAI/config.sqf
+++ b/WAI/config.sqf
@@ -14,11 +14,11 @@ if(isServer) then {
 
 	/* AI CONFIG */
 
-		ai_clear_body 				= false;		// instantly clear bodies
+		ai_clear_weapon 			= false;		// instantly clear weapon and ammo from bodies
 		ai_clean_dead 				= true;			// clear bodies after certain amount of time
 		ai_cleanup_time 			= 7200;			// time to clear bodies in seconds
 		ai_clean_roadkill			= false; 		// clean bodies that are roadkills
-		ai_roadkill_damageweapon	= 0;			// percentage of chance a roadkill will destroy weapon AI is carrying
+		ai_roadkill_damageweapon	= 0;			// percentage of chance a roadkill will destroy everything AI is carrying
 
 		ai_bandit_combatmode		= "YELLOW";		// combatmode of bandit AI
 		ai_bandit_behaviour			= "COMBAT";		// behaviour of bandit AI


### PR DESCRIPTION
Old Clean bodies code cleared everything, not good if AI have keys on them. This code clears only primary weapon and ammo leaving everything else. I am thinking if you don't want the AI to have such things you can set ai_gear array empty? Also updated road kills to remove everything from an AI, e.g including any keys.
